### PR TITLE
Make routing on the WatcherLoop use a single router instance

### DIFF
--- a/src/CondenserDotNet.Client/Services/ServiceRegistry.cs
+++ b/src/CondenserDotNet.Client/Services/ServiceRegistry.cs
@@ -47,8 +47,17 @@ namespace CondenserDotNet.Client.Services
                 if (!_watchedServices.TryGetValue(serviceName, out var watcher))
                 {
                     watcher = new ServiceWatcher(serviceName, _client
-                        , new RandomRoutingStrategy<InformationServiceSet>(), _logger, useNearest: false);
+                        , RandomRoutingStrategy<InformationServiceSet>.Default, _logger, useNearest: false);
                     _watchedServices.Add(serviceName, watcher);
+                }
+                else
+                {
+                    if(watcher.IsNearest)
+                    {
+                        watcher.IsNearest = false;
+                        watcher.RoutingStrategy = RandomRoutingStrategy<InformationServiceSet>.Default;
+                        _logger?.LogInformation("Changed service lookup type for service of {serviceName} from nearest to any random", serviceName);
+                    }
                 }
                 //We either have one or have made one now so lets carry on
                 return watcher.GetNextServiceInstanceAsync();
@@ -61,8 +70,17 @@ namespace CondenserDotNet.Client.Services
             {
                 if (!_watchedServices.TryGetValue(serviceName, out var watcher))
                 {
-                    watcher = new ServiceWatcher(serviceName, _client, new UseTopRouting<InformationServiceSet>(), _logger, useNearest: true);
+                    watcher = new ServiceWatcher(serviceName, _client, UseTopRouting<InformationServiceSet>.Default, _logger, useNearest: true);
                     _watchedServices.Add(serviceName, watcher);
+                }
+                else
+                {
+                    if(!watcher.IsNearest)
+                    {
+                        watcher.IsNearest = true;
+                        watcher.RoutingStrategy = UseTopRouting<InformationServiceSet>.Default;
+                        _logger.LogInformation("Changed service lookup type for service of {serviceName} from any random to nearest", serviceName);
+                    }
                 }
                 return watcher.GetNextServiceInstanceAsync();
             }

--- a/src/CondenserDotNet.Client/Services/ServiceWatcher.cs
+++ b/src/CondenserDotNet.Client/Services/ServiceWatcher.cs
@@ -13,7 +13,7 @@ namespace CondenserDotNet.Client.Services
 {
     internal class ServiceWatcher : IDisposable
     {
-        private readonly IRoutingStrategy<InformationServiceSet> _routingStrategy;
+        private IRoutingStrategy<InformationServiceSet> _routingStrategy;
         private readonly ILogger _logger;
         private readonly string _serviceName;
         private readonly CancellationTokenSource _cancelationToken = new CancellationTokenSource();
@@ -33,7 +33,7 @@ namespace CondenserDotNet.Client.Services
             _logger = logger;
             _routingStrategy = routingStrategy;
             _url = $"{HttpUtils.ServiceHealthUrl}{serviceName}?passing=true";
-            if(_isNearest)
+            if (_isNearest)
             {
                 _url += "&near=_agent";
             }
@@ -42,8 +42,9 @@ namespace CondenserDotNet.Client.Services
             var ignore = WatcherLoop(client);
         }
 
-        public bool IsNearest => _isNearest;
+        public bool IsNearest { get => _isNearest; set => _isNearest = value; }
         public WatcherState State => _state;
+        public IRoutingStrategy<InformationServiceSet> RoutingStrategy { get => _routingStrategy; set => _routingStrategy = value; }
 
         public void SetCallback(Action<List<InformationServiceSet>> callBack)
         {
@@ -70,7 +71,7 @@ namespace CondenserDotNet.Client.Services
                 _logger?.LogWarning("Using old values for service {serviceList}", instances);
             }
             var serviceInstance = _routingStrategy.RouteTo(instances)?.Service;
-            if(serviceInstance == null)
+            if (serviceInstance == null)
             {
                 _logger?.LogWarning("No service instance was found for service name {serviceName}", _serviceName);
             }

--- a/src/CondenserDotNet.Core/Routing/RandomRouteNode.cs
+++ b/src/CondenserDotNet.Core/Routing/RandomRouteNode.cs
@@ -4,6 +4,8 @@ namespace CondenserDotNet.Core.Routing
 {
     public class RandomRoutingStrategy<T> : IRoutingStrategy<T>
     {
+        public static RandomRoutingStrategy<T> Default { get; } = new RandomRoutingStrategy<T>();
+
         public T RouteTo(List<T> instances) => instances?.Count > 0 ? instances[RandHelper.Next(0, instances.Count)] : default;
         public string Name { get; } = RouteStrategy.Random.ToString();
     }

--- a/src/CondenserDotNet.Core/Routing/UseTopRouting.cs
+++ b/src/CondenserDotNet.Core/Routing/UseTopRouting.cs
@@ -6,6 +6,8 @@ namespace CondenserDotNet.Core.Routing
 {
     public class UseTopRouting<T> : IRoutingStrategy<T>
     {
+        public static UseTopRouting<T> Default { get; } = new UseTopRouting<T>();
+
         public string Name => "UseTopRouting";
 
         public T RouteTo(List<T> services) => services?.Count > 0 ? services[0] : default;


### PR DESCRIPTION
Support changing between nearest and random routing on watching services